### PR TITLE
update main.js - add "user left" notification

### DIFF
--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -119,3 +119,14 @@ function getAvatarColor(messageSender) {
 
 usernameForm.addEventListener('submit', connect, true)
 messageForm.addEventListener('submit', send, true)
+
+// Notification message when user leaves the chat
+window.onbeforeunload = sendLeaveMessage
+function sendLeaveMessage() {
+    var chatMessage = {
+            sender: username,
+            type: 'LEAVE'
+        }; 
+    stompClient.send("/app/chat.send", {}, JSON.stringify(chatMessage));
+    return null
+}


### PR DESCRIPTION
Similar to the notification message when a user joins the chat, when the user leaves the chat either by exiting the window or by refreshing the page, the "user left!" notification is displayed on the chat page, which is an intended, but missing functionality in the application.